### PR TITLE
카테고리 기능 및 페이지 만들기

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,9 @@ name = "pypi"
 django = "*"
 pillow = "*"
 beautifulsoup4 = "*"
+install = "*"
+django-extensions = "*"
+ipython = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8632f607e3df1f58a46aec77c290c7661c1fbf4007c3781001340d5e8ab7b9e6"
+            "sha256": "f317cc0f331a8fa0dcb716c9e0508c0fdbea52d6cbd9b5a582dd6b3559774256"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "appnope": {
+            "hashes": [
+                "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24",
+                "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.3"
+        },
         "asgiref": {
             "hashes": [
                 "sha256:89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e",
@@ -23,6 +31,20 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.7.2"
+        },
+        "asttokens": {
+            "hashes": [
+                "sha256:2e0171b991b2c959acc6c49318049236844a5da1d65ba2672c4880c1c894834e",
+                "sha256:cf8fc9e61a86461aa9fb161a14a0841a03c405fa829ac6b202670b3495d2ce69"
+            ],
+            "version": "==2.4.0"
+        },
+        "backcall": {
+            "hashes": [
+                "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e",
+                "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"
+            ],
+            "version": "==0.2.0"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -33,6 +55,14 @@
             "markers": "python_full_version >= '3.6.0'",
             "version": "==4.12.2"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
+                "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==5.1.1"
+        },
         "django": {
             "hashes": [
                 "sha256:08f41f468b63335aea0d904c5729e0250300f6a1907bf293a65499496cdbc68f",
@@ -41,6 +71,79 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==4.2.6"
+        },
+        "django-extensions": {
+            "hashes": [
+                "sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a",
+                "sha256:9600b7562f79a92cbf1fde6403c04fee314608fefbb595502e34383ae8203401"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==3.2.3"
+        },
+        "executing": {
+            "hashes": [
+                "sha256:06df6183df67389625f4e763921c6cf978944721abf3e714000200aab95b0657",
+                "sha256:0ff053696fdeef426cda5bd18eacd94f82c91f49823a2e9090124212ceea9b08"
+            ],
+            "version": "==2.0.0"
+        },
+        "install": {
+            "hashes": [
+                "sha256:0d3fadf4aa62c95efe8d34757c8507eb46177f86c016c21c6551eafc6a53d5a9",
+                "sha256:e67c8a0be5ccf8cb4ffa17d090f3a61b6e820e6a7e21cd1d2c0f7bc59b18e647"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7'",
+            "version": "==1.3.5"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:0852469d4d579d9cd613c220af7bf0c9cc251813e12be647cb9d463939db9b1e",
+                "sha256:ad52f58fca8f9f848e256c629eff888efc0528c12fe0f8ec14f33205f23ef938"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==8.16.1"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd",
+                "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.19.1"
+        },
+        "matplotlib-inline": {
+            "hashes": [
+                "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311",
+                "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.1.6"
+        },
+        "parso": {
+            "hashes": [
+                "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0",
+                "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.8.3"
+        },
+        "pexpect": {
+            "hashes": [
+                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
+                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.8.0"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
         },
         "pillow": {
             "hashes": [
@@ -103,6 +206,44 @@
             "markers": "python_version >= '3.8'",
             "version": "==10.1.0"
         },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac",
+                "sha256:9dffbe1d8acf91e3de75f3b544e4842382fc06c6babe903ac9acb74dc6e08d88"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.0.39"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35",
+                "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"
+            ],
+            "version": "==0.7.0"
+        },
+        "pure-eval": {
+            "hashes": [
+                "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350",
+                "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"
+            ],
+            "version": "==0.2.2"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692",
+                "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.16.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "soupsieve": {
             "hashes": [
                 "sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690",
@@ -118,6 +259,28 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==0.4.4"
+        },
+        "stack-data": {
+            "hashes": [
+                "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9",
+                "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"
+            ],
+            "version": "==0.6.3"
+        },
+        "traitlets": {
+            "hashes": [
+                "sha256:7564b5bf8d38c40fa45498072bf4dc5e8346eb087bbf1e2ae2d8774f6a0f078e",
+                "sha256:98277f247f18b2c5cabaf4af369187754f4fb0e85911d473f72329db8a7f4fae"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==5.11.2"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:77f719e01648ed600dfa5402c347481c0992263b81a027344f3e1ba25493a704",
+                "sha256:8705c569999ffbb4f6a87c6d1b80f324bd6db952f5eb0b95bc07517f4c1813d4"
+            ],
+            "version": "==0.2.8"
         }
     },
     "develop": {}

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -1,5 +1,12 @@
 from django.contrib import admin
-from .models import Post
+from .models import Post, Category
 
 
 admin.site.register(Post)
+
+
+class CategoryAdmin(admin.ModelAdmin):
+    prepopulated_fields = {"slug": ("name",)}
+
+
+admin.site.register(Category, CategoryAdmin)

--- a/blog/models.py
+++ b/blog/models.py
@@ -11,6 +11,9 @@ class Category(models.Model):
     def __str__(self):
         return self.name
 
+    class Meta:
+        verbose_name_plural = "Categories"
+
 
 class Post(models.Model):
     title = models.CharField(max_length=30)

--- a/blog/models.py
+++ b/blog/models.py
@@ -24,7 +24,9 @@ class Post(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     author = models.ForeignKey(User, on_delete=models.CASCADE)
-    category = models.ForeignKey(Category, null=True, on_delete=models.SET_NULL)
+    category = models.ForeignKey(
+        Category, null=True, blank=True, on_delete=models.SET_NULL
+    )
 
     def __str__(self):
         return f"[{self.pk}] {self.title}"

--- a/blog/models.py
+++ b/blog/models.py
@@ -11,6 +11,9 @@ class Category(models.Model):
     def __str__(self):
         return self.name
 
+    def get_absolute_url(self):
+        return f"/blog/category/{self.slug}"
+
     class Meta:
         verbose_name_plural = "Categories"
 

--- a/blog/models.py
+++ b/blog/models.py
@@ -3,6 +3,15 @@ from django.contrib.auth.models import User
 import os
 
 
+class Category(models.Model):
+    name = models.CharField(max_length=50, unique=True)
+    # Slug Field는 사람이 읽을 수 있는 텍스트로 고유 URL을 만들고 싶을 때 사용합니다.
+    slug = models.SlugField(max_length=200, unique=True, allow_unicode=True)
+
+    def __str__(self):
+        return self.name
+
+
 class Post(models.Model):
     title = models.CharField(max_length=30)
     hook_text = models.CharField(max_length=100, blank=True)
@@ -12,6 +21,7 @@ class Post(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     author = models.ForeignKey(User, on_delete=models.CASCADE)
+    category = models.ForeignKey(Category, null=True, on_delete=models.SET_NULL)
 
     def __str__(self):
         return f"[{self.pk}] {self.title}"

--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -34,12 +34,12 @@
                     <div class="card-body">
                         <div class="row">
                             <ul class="list-unstyled mb-0">
-                                <li><a href="#!">Web Design</a></li>
-                                <li><a href="#!">HTML</a></li>
-                                <li><a href="#!">Freebies</a></li>
+                                {% for category in categories %}
+                                <li><a href="{{category.get_absolute_url}}">{{category}} ({{category.post_set.count}})</a></li>
+                                {% endfor %}
+                                <li><a href="/blog/category/no_category">미분류 ({{no_category_post_count}})</a></li>
                             </ul>
                         </div>
-
                     </div>
                 </div>
             </div>

--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -33,7 +33,7 @@
                     <div class="card-header">Categories</div>
                     <div class="card-body">
                         <div class="row">
-                            <ul class="list-unstyled mb-0">
+                            <ul>
                                 {% for category in categories %}
                                 <li><a href="{{category.get_absolute_url}}">{{category}} ({{category.post_set.count}})</a></li>
                                 {% endfor %}

--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -29,29 +29,22 @@
                     </div>
                 </div>
                 <!-- Categories widget-->
-                <div class="card mb-4">
+                <div class="card mb-4" , id="categories-card">
                     <div class="card-header">Categories</div>
                     <div class="card-body">
                         <div class="row">
-                            <div class="col-sm-6">
-                                <ul class="list-unstyled mb-0">
-                                    <li><a href="#!">Web Design</a></li>
-                                    <li><a href="#!">HTML</a></li>
-                                    <li><a href="#!">Freebies</a></li>
-                                </ul>
-                            </div>
-                            <div class="col-sm-6">
-                                <ul class="list-unstyled mb-0">
-                                    <li><a href="#!">JavaScript</a></li>
-                                    <li><a href="#!">CSS</a></li>
-                                    <li><a href="#!">Tutorials</a></li>
-                                </ul>
-                            </div>
+                            <ul class="list-unstyled mb-0">
+                                <li><a href="#!">Web Design</a></li>
+                                <li><a href="#!">HTML</a></li>
+                                <li><a href="#!">Freebies</a></li>
+                            </ul>
                         </div>
+
                     </div>
                 </div>
             </div>
         </div>
+    </div>
     </div>
 
     <!-- Footer-->

--- a/blog/templates/blog/post_detail.html
+++ b/blog/templates/blog/post_detail.html
@@ -9,6 +9,12 @@
 <div class="container mt-5">
     <div class="row">
         <div id="post-area">
+            <!-- Post Category -->
+            {% if post.category %}
+            <span class="badge badge-secondary float-right">{{post.category}}</span>
+            {% else %}
+            <span class="badge badge-secondray float-right">미분류</span>
+            {% endif %}
             <!-- Post content-->
             <article>
                 <!-- Post header-->

--- a/blog/templates/blog/post_list.html
+++ b/blog/templates/blog/post_list.html
@@ -1,7 +1,7 @@
 {% extends 'blog/base.html' %}
 
 {% block main_area %}
-<h1>Blog</h1>
+<h1>Blog {% if category %}<span class="badge badge-secondary">{{category}}</span>{% endif %}</h1>
 {% if post_list.exists %}
 {% for p in post_list %}
 <!-- Featured blog post-->

--- a/blog/templates/blog/post_list.html
+++ b/blog/templates/blog/post_list.html
@@ -5,13 +5,18 @@
 {% if post_list.exists %}
 {% for p in post_list %}
 <!-- Featured blog post-->
-<div class="card mb-4">
+<div class="card mb-4" id="post-{{p.pk}}">
     {% if p.head_image %}
     <a href="#!"><img class="card-img-top" src="{{p.head_image.url}}" alt="..." /></a>
     {% else %}
     <a href="#!"><img class="card-img-top" src="https://picsum.photos/seed/{{p.id}}/800/500" alt="..." /></a>
     {% endif %}
     <div class="card-body">
+        {% if p.category %}
+        <span class="badge badge-secondary float-right">{{p.category}}</span>
+        {% else %}
+        <span class="badge badge-secondray float-right">미분류</span>
+        {% endif %}
         <div class="small text-muted">
             Posted on {{p.created_at}} by
             <a href="#">{{p.author | upper}}</a>

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -38,6 +38,22 @@ class TestView(TestCase):
             author=self.user_obama,
         )
 
+    def test_category_page(self):
+        response = self.client.get(self.category_programming.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        self.navbar_test(soup)
+        self.category_card_test(soup)
+
+        self.assertIn(self.category_programming.name, soup.h1.text)
+
+        main_area = soup.find("div", id="main-area")
+        self.assertIn(self.category_programming.name, main_area.text)
+        self.assertIn(self.post_001.title, main_area.text)
+        self.assertNotIn(self.post_002.title, main_area.text)
+        self.assertNotIn(self.post_003.title, main_area.text)
+
     def category_card_test(self, soup):
         categories_card = soup.find("div", id="categories-card")
         self.assertIn("Categories", categories_card.text)

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -39,7 +39,7 @@ class TestView(TestCase):
         )
 
     def category_card_test(self, soup):
-        categories_card = soup.find("div", id="cateogries-card")
+        categories_card = soup.find("div", id="categories-card")
         self.assertIn("Categories", categories_card.text)
         self.assertIn(
             f"{self.category_programming.name} ({self.category_programming.post_set.count()})",

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -71,38 +71,45 @@ class TestView(TestCase):
         self.assertEqual(logo_btn.attrs["href"], "/about_me/")
 
     def test_post_list(self):
-        # 1.1 포스트 목록 페이지를 가져온다.
+        # 포스트가 있는 경우
+        self.assertEqual(Post.objects.count(), 3)
+
         response = self.client.get("/blog/")
-        # 1.2 정상적인 페이지가 로드된다.
         self.assertEqual(response.status_code, 200)
-        # 1.3 페이지 타이틀은 'Blog'이다.
         soup = BeautifulSoup(response.content, "html.parser")
         self.assertEqual(soup.title.text, "Blog")
 
-        # 1.4 navbar 테스트
         self.navbar_test(soup)
+        self.category_card_test(soup)
 
-        # 2.1 메인 영역에 게시물이 하나도 없다면
-        self.assertEqual(Post.objects.count(), 0)
-        # 2.2 '아직 게시물이 없습니다' 문구가 보인다.
         main_area = soup.find("div", id="main-area")
-        self.assertIn("아직 게시물이 없습니다", main_area.text)
-
-        self.assertEqual(Post.objects.count(), 2)
-        # 3.2 포스트 목록 페이지를 새로고침 했을 때,
-        response = self.client.get("/blog/")
-        soup = BeautifulSoup(response.content, "html.parser")
-        self.assertEqual(response.status_code, 200)
-        # 3.3 메인 영역에 포스트 2개의 타이틀이 존재한다.
-        main_area = soup.find("div", id="main-area")
-        self.assertIn(post_001.title, main_area.text)
-        self.assertIn(post_002.title, main_area.text)
-        # 3.4 '아직 게시물이 없습니다' 문구는 더 이상 보이지 않는다
         self.assertNotIn("아직 게시물이 없습니다", main_area.text)
 
-        # 3.5 User name check
+        post_001_card = main_area.find("div", id="post-1")
+        self.assertIn(self.post_001.title, post_001_card.text)
+        self.assertIn(self.post_001.category.name, post_001_card.text)
+
+        post_002_card = main_area.find("div", id="post-2")
+        self.assertIn(self.post_002.title, post_002_card.text)
+        self.assertIn(self.post_002.category.name, post_002_card.text)
+
+        post_003_card = main_area.find("div", id="post-3")
+        self.assertIn(self.post_003.title, post_003_card.text)
+        self.assertIn("미분류", post_003_card.text)
+
         self.assertIn(self.user_trump.username.upper(), main_area.text)
         self.assertIn(self.user_obama.username.upper(), main_area.text)
+
+        # 포스트가 없는 경우
+        Post.objects.all().delete()
+
+        response = self.client.get("/blog/")
+        self.assertEqual(response.status_code, 200)
+        soup = BeautifulSoup(response.content, "html.parser")
+        self.assertEqual(soup.title.text, "Blog")
+
+        main_area = soup.find("div", id="main-area")
+        self.assertIn("아직 게시물이 없습니다", main_area.text)
 
     def test_post_detail(self):
         # 1.1 포스트가 하나 있다.

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -113,31 +113,32 @@ class TestView(TestCase):
 
     def test_post_detail(self):
         # 1.1 포스트가 하나 있다.
-        post_001 = Post.objects.create(
-            title="첫 번째 포스트입니다.",
-            content="Hello World. We are the one. Thanks",
-            author=self.user_trump,
-        )
+
         # 1.2 그 포스트의 url은 '/blog/1' 이다.
-        self.assertEqual(post_001.get_absolute_url(), "/blog/1/")
+        self.assertEqual(self.post_001.get_absolute_url(), "/blog/1/")
 
         # 2.첫 번째 포스트의 상세 페이지 테스트
         # 2.1 첫 번째 포스트의 url로 접근하면 정상적으로 작동한다.
-        response = self.client.get(post_001.get_absolute_url())
+        response = self.client.get(self.post_001.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, "html.parser")
         # 2.2 navbar 테스트
         self.navbar_test(soup)
+        # 2.3-2 카테고리 테스트
+        self.category_card_test(soup)
+
         # 2.3 첫 번째 포스트의 제목이 웹 브라우저 탭 타이틀에 들어있다.
-        self.assertIn(post_001.title, soup.title.text)
+        self.assertIn(self.post_001.title, soup.title.text)
+
         # 2.4 첫 번째 포스트의 제목이 포스트 영역에 있다.
         main_area = soup.find("div", id="main-area")
         post_area = main_area.find("div", id="post-area")
-        self.assertIn(post_001.title, post_area.text)
+        self.assertIn(self.post_001.title, post_area.text)
+        self.assertIn(self.category_programming.name, post_area.text)
         # 2.5 첫 번째 포스트의 작성자(author)가 포스트 영역에 있다. (아직 구현할 수 없음)
         # 아직 작성 불가
         # 2.6 첫 번째 포스트의 내용(content)이 포스트 영역에 있다.
-        self.assertIn(post_001.content, post_area.text)
+        self.assertIn(self.post_001.content, post_area.text)
 
         # 2.7 User name check
         self.assertIn(self.user_trump.username.upper(), post_area.text)

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path("category/<str:slug>", views.category_page),
     path("<int:pk>/", views.PostDetail.as_view()),
     path("", views.PostList.as_view()),
 ]

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,10 +1,16 @@
 from django.views.generic import ListView, DetailView
-from .models import Post
+from .models import Post, Category
 
 
 class PostList(ListView):
     model = Post
     ordering = "-pk"
+
+    def get_context_data(self, **kwargs):
+        context = super(PostList, self).get_context_data()
+        context["categories"] = Category.objects.all()
+        context["no_category_post_count"] = Post.objects.filter(category=None).count()
+        return context
 
 
 class PostDetail(DetailView):

--- a/blog/views.py
+++ b/blog/views.py
@@ -15,3 +15,9 @@ class PostList(ListView):
 
 class PostDetail(DetailView):
     model = Post
+
+    def get_context_data(self, **kwargs):
+        context = super(PostDetail, self).get_context_data()
+        context["categories"] = Category.objects.all()
+        context["no_category_post_count"] = Post.objects.filter(category=None).count()
+        return context

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,3 +1,4 @@
+from django.shortcuts import render
 from django.views.generic import ListView, DetailView
 from .models import Post, Category
 
@@ -21,3 +22,23 @@ class PostDetail(DetailView):
         context["categories"] = Category.objects.all()
         context["no_category_post_count"] = Post.objects.filter(category=None).count()
         return context
+
+
+def category_page(request, slug):
+    if slug == "no_category":
+        category = "미분류"
+        post_list = Post.objects.filter(category=None)
+    else:
+        category = Category.objects.get(slug=slug)
+        post_list = Post.objects.filter(category=category)
+
+    return render(
+        request,
+        "blog/post_list.html",
+        {
+            "post_list": post_list,
+            "categories": Category.objects.all(),
+            "no_category_post_count": Post.objects.filter(category=None).count(),
+            "category": category,
+        },
+    )

--- a/do_it_django_prj/settings.py
+++ b/do_it_django_prj/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_extensions",
     "blog",
     "single_pages",
 ]


### PR DESCRIPTION
<!-- e.g. Resolves #10, resolves #123 -->

Resolves #39 

## What is this PR?

카테고리 기능 구현을 하고 이에 맞춰 페이지를 업데이트 합니다.
카테고리 페이지를 따로 만들어서, 카테고리별로 포스트를 모아볼 수 있게 합니다.

## Changes

- Post에 카테고리 추가
- 카테고리 별로 Post List를 보여주는 페이지 구현

## Screenshot

- Post 목록 페이지 (위젯 업데이트, 요약문에 카테고리 출력)
  <img width="750" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/63959409-8ae7-418a-b7b9-ff5727999f88">

- Post 상세 페이지 (위젯 업데이트, 상세 페이지에 카테고리 출력)
  <img width="750" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/bbc2ec98-7d61-4d87-b013-da71fb57355f">

- 카테고리 페이지 (카테고리를 표시하고, 해당 포스트만 출력) - 목록 페이지와 비슷
  <img width="750" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/72d0738b-6a86-4c38-a7e9-f83883fed357">
