### PR TITLE
CreatePost, UpdatePost 폼 모양 개선

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ install = "*"
 django-extensions = "*"
 ipython = "*"
 django-crispy-forms = "*"
+crispy-bootstrap4 = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ beautifulsoup4 = "*"
 install = "*"
 django-extensions = "*"
 ipython = "*"
+django-crispy-forms = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6d67d7edc4e1d805e03289c3be1761b71c3aab5abc1cf87159ea4adcf82e7076"
+            "sha256": "b848afe711dc7eb5d584eea16891da924b28efdf2b252079eb21c2d1ee93002b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -54,6 +54,15 @@
             "index": "pypi",
             "markers": "python_full_version >= '3.6.0'",
             "version": "==4.12.2"
+        },
+        "crispy-bootstrap4": {
+            "hashes": [
+                "sha256:1a88e74f8d36d2dedeb40a66f246994f3ce5cd855017785d0291e741d3e7d7c2",
+                "sha256:d60e93eb6d82886c009eb174f2a4c78fdac602a1efadf0305471c84815bd973a"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2023.1"
         },
         "decorator": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f317cc0f331a8fa0dcb716c9e0508c0fdbea52d6cbd9b5a582dd6b3559774256"
+            "sha256": "6d67d7edc4e1d805e03289c3be1761b71c3aab5abc1cf87159ea4adcf82e7076"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,10 +34,10 @@
         },
         "asttokens": {
             "hashes": [
-                "sha256:2e0171b991b2c959acc6c49318049236844a5da1d65ba2672c4880c1c894834e",
-                "sha256:cf8fc9e61a86461aa9fb161a14a0841a03c405fa829ac6b202670b3495d2ce69"
+                "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24",
+                "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0"
             ],
-            "version": "==2.4.0"
+            "version": "==2.4.1"
         },
         "backcall": {
             "hashes": [
@@ -71,6 +71,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==4.2.6"
+        },
+        "django-crispy-forms": {
+            "hashes": [
+                "sha256:4d7ec431933ad4d4b5c5a6de4a584d24613c347db9ac168723c9aaf63af4bb96",
+                "sha256:d592044771412ae1bd539cc377203aa61d4eebe77fcbc07fbc8f12d3746d4f6b"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1"
         },
         "django-extensions": {
             "hashes": [
@@ -269,11 +278,11 @@
         },
         "traitlets": {
             "hashes": [
-                "sha256:7564b5bf8d38c40fa45498072bf4dc5e8346eb087bbf1e2ae2d8774f6a0f078e",
-                "sha256:98277f247f18b2c5cabaf4af369187754f4fb0e85911d473f72329db8a7f4fae"
+                "sha256:81539f07f7aebcde2e4b5ab76727f53eabf18ad155c6ed7979a681411602fa47",
+                "sha256:833273bf645d8ce31dcb613c56999e2e055b1ffe6d09168a164bcd91c36d5d35"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.11.2"
+            "version": "==5.12.0"
         },
         "wcwidth": {
             "hashes": [

--- a/blog/templates/blog/post_form.html
+++ b/blog/templates/blog/post_form.html
@@ -1,18 +1,17 @@
 {% extends 'blog/base_full_width.html' %}
-
+{% load crispy_forms_tags %}
 {% block head_title %}Create Post - Blog{% endblock %}
 
 {% block main_area %}
 <h1>Create New Post</h1>
 <hr />
 <form method="post" enctype="multipart/form-data">{% csrf_token %}
-    <table>
-        {{form}}
-        <tr>
-            <th><label for="id_tags_str">Tags:</label></th>
-            <td><input type="text" name="tags_str" id="id_tags_str"></td>
-        </tr>
-    </table>
+    {{form | crispy}}
+    <div id="" div_id_tags_str>
+        <label for="id_tags_str">Tags:</label>
+        <input type="text" name="tags_str" id="id_tags_str" class="textinput textInput form-control">
+    </div>
+    <br />
     <button type="submit" class="btn btn-primary float-right">Submit</button>
 </form>
 {% endblock %}

--- a/blog/templates/blog/post_update_form.html
+++ b/blog/templates/blog/post_update_form.html
@@ -1,18 +1,18 @@
 {% extends 'blog/base_full_width.html' %}
-
+{% load crispy_forms_tags %}
 {% block head_title %}Edit Post - Blog{% endblock %}
 
 {% block main_area %}
 <h1>Edit Post</h1>
 <hr />
 <form method="post" enctype="multipart/form-data">{% csrf_token %}
-    <table>
-        {{form}}
-        <tr>
-            <th><label for="id_tags_str">Tags:</label></th>
-            <td><input type="text" name="tags_str" id="id_tags_str" value="{{ tags_str_default }}"></td>
-        </tr>
-    </table>
+    {{form | crispy}}
+    <div id="" div_id_tags_str>
+        <label for="id_tags_str">Tags:</label>
+        <input type="text" name="tags_str" id="id_tags_str" value="{{ tags_str_default }}"
+            class="textinput textInput form-control">
+    </div>
+    <br />
     <button type=" submit" class="btn btn-primary float-right">Submit</button>
 </form>
 {% endblock %}

--- a/do_it_django_prj/settings.py
+++ b/do_it_django_prj/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_extensions",
+    "crispy_forms",
     "blog",
     "single_pages",
 ]
@@ -123,6 +124,7 @@ STATIC_URL = "static/"
 
 MEDIA_URL = "media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "_media")
+CRISPY_TEMPLATE_PACK = "bootstrap4"
 
 
 # Default primary key field type

--- a/do_it_django_prj/settings.py
+++ b/do_it_django_prj/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django_extensions",
     "crispy_forms",
+    "crispy_bootstrap4",
     "blog",
     "single_pages",
 ]
@@ -124,6 +125,7 @@ STATIC_URL = "static/"
 
 MEDIA_URL = "media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "_media")
+CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap4"
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
 


### PR DESCRIPTION
<!-- e.g. Resolves #10, resolves #123 -->

Resolves #49 

## What is this PR?

Django Crispy 라이브러리를 사용해서 Post 생성, Post 수정을 수행하는 폼의 디자인을 개선합니다.

## Changes

- Django Crispy 설치
- post_form, post_update_form 에 Django Crispy 적용

## Screenshot

- 변경 전 (Edit Post도 동일)
  <img width="708" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/ed323264-db07-4a80-b931-b55bc1a19257">
- 변경 후 (Edit Post도 동일)
  <img width="710" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/5177679e-6026-4173-b9e1-49fa036f4312">


## Reference
- ```TemplateDoesNotExist: bootstrap4/uni_form.html``` 에러 해결하기
  책을 그대로 따라했을 때, bootstrap4의 버전 변경 때문에 에러가 발생하는데, 아래 링크에서 crispy bootstrap을 설치해서 해결합니다.
  참고링크 1 https://www.reddit.com/r/django/comments/133s4j9/templatedoesnotexist_bootstrap4uni_formhtml/
  참고링크 2 https://pypi.org/project/crispy-bootstrap4/
   
 
