### PR TITLE
구글 클라이언트 세팅 추가

### DIFF
--- a/do_it_django_prj/settings.py
+++ b/do_it_django_prj/settings.py
@@ -150,3 +150,22 @@ SITE_ID = 1
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = "none"
 LOGIN_REDIRECT_URL = "/blog/"
+
+SOCIALACCOUNT_PROVIDERS = {
+    "google": {
+        "APP": {
+            "client_id": os.getenv("GOOGLE_CLIENT_ID"),
+            "secret": os.getenv("GOOGLE_SECRET_KEY"),
+            "key": "",
+        },
+        # These are provider-specific settings that can only be
+        # listed here:
+        "SCOPE": [
+            "profile",
+            "email",
+        ],
+        "AUTH_PARAMS": {
+            "access_type": "online",
+        },
+    }
+}


### PR DESCRIPTION
<!-- e.g. Resolves #10, resolves #123 -->

Resolves #59

## What is this PR?

테스트 환경에서 소셜앱 에러가 나지 않도록, Google Client 아이디와 키를 settings에 추가합니다.
추가하는 방식은 get_env로 로컬의 환경변수를 추가합니다.

## Changes

- Local 환경변수로, GOOGLE_CLIENT_ID와 GOOGLE_SECRET_KEY를 추가
  <img width="631" alt="Screenshot 2023-11-01 at 11 23 38 PM" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/a130053a-3d89-4431-bf27-34595260d28d">

- setting에서 get_env로 해당 변수를 읽어서, 테스트 환경에서도 소셜로그인 기능에 문제가 없도록 변경