### PR TITLE
댓글 수정기능 구현하기

### DIFF
--- a/blog/templates/blog/comment_form.html
+++ b/blog/templates/blog/comment_form.html
@@ -1,0 +1,13 @@
+{% extends 'blog/base_full_width.html' %}
+{% load crispy_forms_tags %}
+{% block head_title %}Edit Comment - Blog{% endblock %}
+
+{% block main_area %}
+<h1>Edit Comment</h1>
+<hr />
+<form method="post" id="comment-form">{% csrf_token %}
+    {{form| crispy}}
+    <br />
+    <button type="submit" class="btn btn-primary float-right">Submit</button>
+</form>
+{% endblock %}

--- a/blog/templates/blog/post_detail.html
+++ b/blog/templates/blog/post_detail.html
@@ -101,21 +101,32 @@
                         </div>
                         {% if post.comment_set.exists %}
                         {% for comment in post.comment_set.iterator %}
+
                         <!-- Single comment-->
                         <div class="media mb-4" id="comment-{{comment.pk}}">
                             <img class="d-flex mr-3 rounded-circle" src="http://placehold.it/50x50" alt="">
                             <div class="media-body">
-                                <h5 class="mt-0">{{comment.author.username}} &nbsp;&nbsp;
-                                    <small class="text-muted">{{comment.created_at}}</small>
+                                {% if user.is_authenticated and comment.author == user %}
+                                <div class="float-right">
+                                    <a role="button" class="btn btn-sm btn-info" id="comment-{{comment.pk}}-update-btn"
+                                        href="/blog/update_comment/{{comment.pk}}/">
+                                        edit</a>
+                                </div>
+                                {% endif %}
+                                <h5 class="mt-0">
+                                    {{comment.author.username}}
+                                    &nbsp;&nbsp;<small class="text-muted">{{comment.created_at}}</small>
                                 </h5>
                                 <p>{{comment.content|linebreaks}}</p>
+                                {% if comment.created_at|date:"Y-m-d H:i:s" != comment.modified_at|date:"Y-m-d H:i:s" %}
+                                <p class="text-muted float-right"><small>updated :
+                                        {{comment.modified_at}}</small></p>
+                                {% endif %}
                             </div>
-
                         </div>
                         {% endfor %}
                         {% endif %}
                     </div>
-
                 </div>
             </section>
         </div>

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase, Client
 from bs4 import BeautifulSoup
 from django.contrib.auth.models import User
 from .models import Post, Category, Tag, Comment
+import time
 
 
 class TestView(TestCase):
@@ -343,7 +344,7 @@ class TestView(TestCase):
         )
 
         response = self.client.get(self.post_001.get_absolute_url())
-        self.assertEqual(reponse.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, "html.parser")
 
         ### button check ###
@@ -353,12 +354,13 @@ class TestView(TestCase):
         self.assertFalse(comment_area.find("a", id="comment-2-update-btn"))
 
         # with login
-        self.client.login(username="obama", password="somepasword")
-        reponse = self.client.get(self.post_001.get_absolute_url())
+        self.client.login(username="Obama", password="somepassword")
+        response = self.client.get(self.post_001.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, "html.parser")
 
         comment_area = soup.find("div", id="comment-area")
+        comment_area.find("a", id="comment-1-update-btn")
         self.assertFalse(comment_area.find("a", id="comment-2-update-btn"))
         comment_001_update_btn = comment_area.find("a", id="comment-1-update-btn")
 
@@ -376,7 +378,7 @@ class TestView(TestCase):
         update_comment_form = soup.find("form", id="comment-form")
         content_text_area = update_comment_form.find("textarea", id="id_content")
         self.assertIn(self.comment_001.content, content_text_area.text)
-
+        time.sleep(1)
         response = self.client.post(
             f"/blog/update_comment/{self.comment_001.pk}/",
             {

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -336,3 +336,57 @@ class TestView(TestCase):
         new_comment_div = comment_area.find("div", id=f"comment-{new_comment.pk}")
         self.assertIn("Obama", new_comment_div.text)
         self.assertIn("오바마의 댓글 입니다.", new_comment_div.text)
+
+    def test_comment_update(self):
+        comment_by_trump = Comment.objects.create(
+            post=self.post_001, author=self.user_trump, content="트럼프의 댓글 입니다."
+        )
+
+        response = self.client.get(self.post_001.get_absolute_url())
+        self.assertEqual(reponse.status_code, 200)
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        ### button check ###
+        # without login
+        comment_area = soup.find("div", id="comment-area")
+        self.assertFalse(comment_area.find("a", id="comment-1-update-btn"))
+        self.assertFalse(comment_area.find("a", id="comment-2-update-btn"))
+
+        # with login
+        self.client.login(username="obama", password="somepasword")
+        reponse = self.client.get(self.post_001.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        comment_area = soup.find("div", id="comment-area")
+        self.assertFalse(comment_area.find("a", id="comment-2-update-btn"))
+        comment_001_update_btn = comment_area.find("a", id="comment-1-update-btn")
+
+        ### button function check ###
+        self.assertIn("edit", comment_001_update_btn.text)
+        self.assertEqual(
+            comment_001_update_btn.attrs["href"], "/blog/update_comment/1/"
+        )
+
+        response = self.client.get("/blog/update_comment/1/")
+        self.assertEqual(response.status_code, 200)
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        self.assertEqual("Edit Comment - Blog", soup.title.text)
+        update_comment_form = soup.find("form", id="comment-form")
+        content_text_area = update_comment_form.find("textarea", id="id_content")
+        self.assertIn(self.comment_001.content, content_text_area.text)
+
+        response = self.client.post(
+            f"/blog/update_comment/{self.comment_001.pk}/",
+            {
+                "content": "오바마의 댓글을 수정합니다.",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        soup = BeautifulSoup(response.content, "html.parser")
+        comment_001_div = soup.find("div", id="comment-1")
+        self.assertIn("오바마의 댓글을 수정합니다.", comment_001_div.text)
+        self.assertIn("updated :", comment_001_div.text)

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path("update_comment/<int:pk>/", views.CommentUpdate.as_view()),
     path("update_post/<int:pk>/", views.PostUpdate.as_view()),
     path("create_post/", views.PostCreate.as_view()),
     path("tag/<str:slug>", views.tag_page),

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.generic import ListView, DetailView, CreateView, UpdateView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from .models import Post, Category, Tag
+from .models import Post, Category, Tag, Comment
 from .forms import CommentForm
 from django.core.exceptions import PermissionDenied
 from django.utils.text import slugify
@@ -170,5 +170,16 @@ def new_comment(request, pk):
                 return redirect(comment.get_absolute_url())
             else:
                 return redirect(post.get_absolute_url())
+        else:
+            return PermissionDenied
+
+
+class CommentUpdate(LoginRequiredMixin, UpdateView):
+    model = Comment
+    form_class = CommentForm
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated and request.user == self.get_object().author:
+            return super(CommentUpdate, self).dispatch(request, *args, **kwargs)
         else:
             return PermissionDenied


### PR DESCRIPTION
<!-- e.g. Resolves #10, resolves #123 -->

Resolves #63

## What is this PR?

댓글의 수정기능을 구현합니다.

## Changes

- 버튼 누르면, 수정을 진행시킬 수 있는 CommentUpdate view 만들기
- Comment Form 만들기

## Screenshot

- Edit Comment
  ![ezgif com-video-to-gif](https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/ed78fa93-9e3f-48b4-98a0-537f158e63e6)

## Reference

- 기본 책과 두 가지 부분에서 다릅니다.

1. 장고 업데이트 때문인지? 새롭게 만든 댓글에서 created_at 과 updated_at의 시간이 같지 않습니다.
따라서, 같은 연도, 월, 일, 시간, 분, 초가 같다면 같은 댓글로 판단할 수 있게 아래처럼 코드를 수정합니다.
- 기존 코드
  ```html
  {% if comment.modified_at != comment.created_at %}
   ```
- 수정한 코드
  ```html
  {% if comment.created_at|date:"Y-m-d H:i:s" != comment.modified_at|date:"Y-m-d H:i:s" %}
   ```

2. 테스트코드를 돌리다보면, 댓글의 생성과 수정이 1초 안에 이루어지기 때문에, 수정 하더라도, update 멘트가 없습니다.
이를 해결하기 위해, 테스트 환경에서 댓글 수정을 하기 전에 1초 쉬는 로직을 넣습니다.
- 기존 코드
  ```python
  self.assertIn(self.comment_001.content, content_text_area.text)
  response = self.client.post(.... 생략)
  ```
- 수정한 코드
  ```python
  self.assertIn(self.comment_001.content, content_text_area.text)
  time.sleep(1)
  response = self.client.post(.... 생략)
  ```

3. 책에 있는 코드대로 하면, edit 버튼이 comment box 외부에 있게 되어, edit 버튼이 맨 오른쪽을 차지했을 때, comment box의 update 문구는 맨 오른쪽으로 붙지 못 합니다. (이미 box자체가 edit버튼의 왼쪽)
이를 해결하기 위해, comment box 내부에 edit 버튼이 있도록 수정했습니다.
- 수정 전
  <img width="577" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/65de3d78-6d8b-4d0c-9fef-6b32993d4048">

- 수정 후
  <img width="573" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/92d4560f-7843-435b-bd85-a67e0b7da43a">


