### PR TITLE
댓글 및 로그인시 사진 기능 추가

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -73,3 +73,9 @@ class Comment(models.Model):
 
     def get_absolute_url(self):
         return f"{self.post.get_absolute_url()}#comment-{self.pk}"
+
+    def get_avatar_url(self):
+        if self.author.socialaccount_set.exists():
+            return self.author.socialaccount_set.first().get_avatar_url()
+        else:
+            return f"https://doitdjango.com/avatar/id/1760/ee208b31f61c0f58/svg/{self.author.email}"

--- a/blog/models.py
+++ b/blog/models.py
@@ -77,5 +77,7 @@ class Comment(models.Model):
     def get_avatar_url(self):
         if self.author.socialaccount_set.exists():
             return self.author.socialaccount_set.first().get_avatar_url()
-        else:
+        elif self.author.email:
             return f"https://doitdjango.com/avatar/id/1760/ee208b31f61c0f58/svg/{self.author.email}"
+        else:
+            return f"https://placehold.it/50x50"

--- a/blog/templates/blog/navbar.html
+++ b/blog/templates/blog/navbar.html
@@ -23,6 +23,14 @@
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button"
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        {% if user.socialaccount_set.all.0.get_avatar_url %}
+                        <img class="rounded-circle" width="25px" alt=""
+                            src="{{user.socialaccount_set.all.0.get_avatar_url}}">
+                        {% else %}
+                        <img class="rounded-circle" width="25px"
+                            src="https://doitdjango.com/avatar/id/1760/ee208b31f61c0f58/svg/{{user.email}}">
+                        {% endif %}
+                        &nbsp;
                         {{ user.username }}
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">

--- a/blog/templates/blog/post_detail.html
+++ b/blog/templates/blog/post_detail.html
@@ -104,7 +104,8 @@
 
                         <!-- Single comment-->
                         <div class="media mb-4" id="comment-{{comment.pk}}">
-                            <img class="d-flex mr-3 rounded-circle" src="http://placehold.it/50x50" alt="">
+                            <img class="d-flex mr-3 rounded-circle" src="{{comment.get_avatar_url}}"
+                                alt="{{comment.author}}" width="60px">
                             <div class="media-body">
                                 {% if user.is_authenticated and comment.author == user %}
                                 <div class="float-right">


### PR DESCRIPTION
<!-- e.g. Resolves #10, resolves #123 -->

Resolves #72

## What is this PR?

댓글 및 로그인 할 때 마다 avatar(사진)이 함께 뜨게 변경합니다.

## Changes

- Comment 모델에서 url 받아와서 html에 뿌려주기
- Login은 navbar html에서 바로 url 입력해서 html에 뿌려주기

## Screenshot

- Comment (구글 계정로그인이 아닌 경우, 이메일 기반 랜덤한 이미지 출력)
  <img width="837" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/0d64514f-4a05-4ae9-9583-1ddd4630dade">

- Login (구글 계정의 이미지가 나옵니다)
  <img width="1120" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/9b4fc000-f0f1-4cbd-a580-3c42bd4fbbb4">
