### PR TITLE
Tag 생성버그 해결

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -61,6 +61,8 @@ class PostCreate(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
                 for t in tags_list:
                     t = t.strip()
+                    if not t:
+                        continue
                     tag, is_tag_created = Tag.objects.get_or_create(name=t)
                     if is_tag_created:
                         tag.slug = slugify(t, allow_unicode=True)
@@ -110,9 +112,10 @@ class PostUpdate(LoginRequiredMixin, UpdateView):
             tags_str = tags_str.strip()
             tags_str = tags_str.replace(",", ";")
             tags_list = tags_str.split(";")
-
             for t in tags_list:
                 t = t.strip()
+                if not t:
+                    continue
                 tag, is_tag_created = Tag.objects.get_or_create(name=t)
                 if is_tag_created:
                     tag.slug = slugify(t, allow_unicode=True)


### PR DESCRIPTION
<!-- e.g. Resolves #10, resolves #123 -->

Resolves #88 

## What is this PR?

새로운 Tag를 생성해서 Post를 만들거나 업데이트하면 500번 에러가 뜨는 버그 해결

## Changes

- form 에서 tags_str 에서 받아온 tag들을 split할 때, none값은 무시하도록 코드를 수정

## Reference

- 원인을 파악해보니, Tag를 ';' 기준으로 나누는데, 만약 맨 마지막 tag에 ';'를 달면 none 값의 tag 값이 생성됩니다.
  ```tag1; tag2; tag3``` : 문제없음
  ```tag1; tag2; tag3;``` : 문제있음
- 이럴 경우, none 값의 생성된 태그가 다른 tag의 생성을 막습니다. 정확한 원인은 모르겠지만, none 값의 tag자체가 올바른 상황이 아니므로 이러한 케이스가 생기지 않도록 none 이면, tag가 생성되지 않도록 합니다.
