### PR TITLE
Dev, Prod 환경에서 참고하는 데이터베이스 분리하기

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,5 @@
 DEBUG = 1
-SECRET_KEY = django-insecure-e6i-sgs9x#3gdu!39*1u6q!mul)cvt8^afl&zae(+f&mb%@39@
+SECRET_KEY = e6i-sgs9x#3gdu!39*1u6q!mul)cvt8^afl&zae(+f&mb%@39@
 DJANGO_ALLOWED_HOSTS = localhost 127.0.0.1 [::1]
 SQL_ENGINE=django.db.backends.postgresql
 SQL_DATABASE=do_it_django_dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,14 +1,26 @@
 version: '3'
 
 services:
+  nginx:
+    build: ./nginx
+    volumes:
+      - static_volume:/usr/src/app/_static
+      - media_volume:/usr/src/app/_media
+    ports:
+      - 80:80
+    depends_on:
+      - web
+
   web:
     build: .
     command: >
-      sh -c "python manage.py migrate && gunicorn do_it_django_prj.wsgi:application --bind 0.0.0.0:8000"
+      sh -c "python manage.py makemigrations && python manage.py migrate && gunicorn do_it_django_prj.wsgi:application --bind 0.0.0.0:8000"
     volumes:
+      - static_volume:/usr/src/app/_static
+      - media_volume:/usr/src/app/_media
       - ./:/usr/src/app
-    ports:
-      - 8000:8000
+    expose:
+      - 8000
     env_file:
       - ./.env.dev
     depends_on:
@@ -17,11 +29,13 @@ services:
   db:
     image: postgres:12.0-alpine
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - dev_postgres_data:/var/lib/postgresql/data/
     environment:
       - POSTGRES_USER=do_it_django_db_user
       - POSTGRES_PASSWORD=do_it_django_db_password
       - POSTGRES_DB=do_it_django_dev
 
 volumes:
-  postgres_data:
+  dev_postgres_data:
+  static_volume:
+  media_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   web:
     build: .
     command: >
-      sh -c "python manage.py migrate && gunicorn do_it_django_prj.wsgi:application --bind 0.0.0.0:8000"
+      sh -c "python manage.py makemigrations && python manage.py migrate && gunicorn do_it_django_prj.wsgi:application --bind 0.0.0.0:8000"
     volumes:
       - static_volume:/usr/src/app/_static
       - media_volume:/usr/src/app/_media


### PR DESCRIPTION
Resolves #94

## What is this PR?

dev 환경의 자유함을 높이기 위해, dev 환경에서 데이터베이스를 분리합니다.

## Changes

- docker-compose.dev.yml에서, 참조하는 Host volume 수정
- .env.dev 에서 잘못된 Secret Key 값 수정
- docker-compose에 더 나은 자동화를 위해 makemigrations 추가

## Reference

- (나만 볼 수 있음)
  https://www.notion.so/Docker-bafdbf77eaca4142ba66ada5326b5378?pvs=4#a5452f2f51a04c8090c369fdfe61e826
- 요약하면, docker-compose 의 host volume 개념과, instance 내부 volume의 연결하는 부분에서, host volume이 같다면 같은 데이터베이스 volume을 참조하기 때문에, 주의해야 한다.