### PR TITLE
게시글 없을 때, 빈 공간 추가

### DIFF
--- a/blog/templates/blog/post_list.html
+++ b/blog/templates/blog/post_list.html
@@ -55,7 +55,9 @@
 </div>
 {% endfor %}
 {% else %}
-<h3>아직 게시물이 없습니다.</h3>
+<div style="height: 650px;">
+    <h3>아직 게시물이 없습니다.</h3>
+</div>
 {% endif %}
 {% if is_paginated %}
 <!-- Pagination-->


### PR DESCRIPTION


Resolves #93

## What is this PR?

게시글 없을 때, footer가 맨 아래 고정이 안 되었습니다. 이를 해결하기 위해 여러 방법을 모색했고,
가장 간단하게 게시글이 없을 때, 빈 공간을 추가했습니다.

## Changes

- 게시글 없을 때 빈 공간 추가

## Screenshot

- 변경 전
  <img width="1000" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/3ddfc4de-5b91-4d55-b3b7-c9afbb6bd118">

- 변경 후
  <img width="1000" alt="image" src="https://github.com/soonyoung-hwang/Blog-Django-Bootstrap/assets/78343941/1aff0355-2297-42c2-ba49-f732f23712d1">


